### PR TITLE
Fix previous bugfix which doesn't really solve the problem

### DIFF
--- a/sense platform/CSSettings.m
+++ b/sense platform/CSSettings.m
@@ -227,7 +227,9 @@ static CSSettings* sharedSettingsInstance = nil;
     NSString* key = [NSString stringWithFormat:@"%@", sensor];
     if (persistent) {
         //store enable settings
-        [sensorEnables setObject:enableObject forKey:key];
+        @synchronized(settings) {
+            [sensorEnables setObject:enableObject forKey:key];
+        }
         //write back to file
         [self storeSettings];
     }
@@ -337,8 +339,7 @@ static CSSettings* sharedSettingsInstance = nil;
 		NSLog(@"Error reading plist: %@, format: %ul", errorDesc, (unsigned)format);
 		return;
 	}
-    sensorEnables = [[settings valueForKey:@"sensorEnables"] mutableCopy];
-
+	sensorEnables = [settings valueForKey:@"sensorEnables"];
 	if (sensorEnables == nil) {
 		sensorEnables = [NSMutableDictionary new];
 		[settings setObject:sensorEnables forKey:@"sensorEnables"];
@@ -355,7 +356,7 @@ static CSSettings* sharedSettingsInstance = nil;
 		NSLog(@"Error loading settings from dictionary.");
 		return;
 	}
-	sensorEnables = [[settings valueForKey:@"sensorEnables"] mutableCopy];
+	sensorEnables = [settings valueForKey:@"sensorEnables"];
 	if (sensorEnables == nil) {
 		sensorEnables = [NSMutableDictionary new];
 		[settings setObject:sensorEnables forKey:@"sensorEnables"];
@@ -369,11 +370,7 @@ static CSSettings* sharedSettingsInstance = nil;
             NSString *rootPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
             NSString *plistPath = [rootPath stringByAppendingPathComponent:@"Settings.plist"];
             
-            // persist the sensorEnables
-            [settings setObject:sensorEnables forKey:@"sensorEnables"];
-            
             NSData *plistData;
-
             plistData = [NSPropertyListSerialization dataWithPropertyList:settings format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
             
             if(plistData) {

--- a/sense platform/CSSettings.m
+++ b/sense platform/CSSettings.m
@@ -342,7 +342,10 @@ static CSSettings* sharedSettingsInstance = nil;
 	sensorEnables = [settings valueForKey:@"sensorEnables"];
 	if (sensorEnables == nil) {
 		sensorEnables = [NSMutableDictionary new];
-		[settings setObject:sensorEnables forKey:@"sensorEnables"];
+        
+        @synchronized(settings) {
+            [settings setObject:sensorEnables forKey:@"sensorEnables"];
+        }
 	}
 }
 
@@ -359,7 +362,9 @@ static CSSettings* sharedSettingsInstance = nil;
 	sensorEnables = [settings valueForKey:@"sensorEnables"];
 	if (sensorEnables == nil) {
 		sensorEnables = [NSMutableDictionary new];
-		[settings setObject:sensorEnables forKey:@"sensorEnables"];
+        @synchronized(settings) {
+            [settings setObject:sensorEnables forKey:@"sensorEnables"];
+        }
 	}
 }
 


### PR DESCRIPTION
As it turn's out sensorEnables are intentended to be part of `settings`.
we just did not realize when we set sensor enabled, it modify the `settings`
but not guarding it.