### PR TITLE
Feature/add visits monitoring

### DIFF
--- a/SensePlatform.xcodeproj/project.pbxproj
+++ b/SensePlatform.xcodeproj/project.pbxproj
@@ -86,7 +86,7 @@
 		3E820E2715D40B190001A3EC /* CSConnectionSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DE515D40B180001A3EC /* CSConnectionSensor.m */; };
 		3E820E2915D40B190001A3EC /* CSDynamicSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DE715D40B180001A3EC /* CSDynamicSensor.m */; };
 		3E820E2B15D40B190001A3EC /* CSJumpSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DE915D40B180001A3EC /* CSJumpSensor.m */; };
-		3E820E2D15D40B190001A3EC /* CSLocationSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DEB15D40B180001A3EC /* CSLocationSensor.m */; };
+		3E820E2D15D40B190001A3EC /* CSLocationProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DEB15D40B180001A3EC /* CSLocationProvider.m */; };
 		3E820E3115D40B190001A3EC /* CSMotionEnergySensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DEF15D40B180001A3EC /* CSMotionEnergySensor.m */; };
 		3E820E3315D40B190001A3EC /* CSMotionFeaturesSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DF115D40B180001A3EC /* CSMotionFeaturesSensor.m */; };
 		3E820E3515D40B190001A3EC /* CSMovingSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E820DF315D40B180001A3EC /* CSMovingSensor.m */; };
@@ -110,6 +110,8 @@
 		3E9C158415D574E700F520D0 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9C158315D574E700F520D0 /* CoreLocation.framework */; };
 		3EE091ED18FD597300A04ED4 /* CSSensorIdKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE091EC18FD597300A04ED4 /* CSSensorIdKey.m */; };
 		3EF47FBA19093D3E00104D69 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EF47FB919093D3E00104D69 /* NSData+GZIP.m */; };
+		A9902AB41A9F591A00FCB951 /* CSLocationSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = A9902AB31A9F591A00FCB951 /* CSLocationSensor.m */; };
+		A9902AB71A9F594500FCB951 /* CSVisitsSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = A9902AB61A9F594500FCB951 /* CSVisitsSensor.m */; };
 		A99F99CF1A5D16D300D6CB76 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E148BD0160A18DC0010A0D1 /* UIKit.framework */; };
 		A99F99D41A5D18B100D6CB76 /* CSStorageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A99F99D31A5D18B100D6CB76 /* CSStorageTest.m */; };
 		A99F99D51A5D8A5D00D6CB76 /* libSensePlatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E820D6A15D40AB50001A3EC /* libSensePlatform.a */; };
@@ -260,8 +262,8 @@
 		3E820DE715D40B180001A3EC /* CSDynamicSensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSDynamicSensor.m; sourceTree = "<group>"; };
 		3E820DE815D40B180001A3EC /* CSJumpSensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSJumpSensor.h; sourceTree = "<group>"; };
 		3E820DE915D40B180001A3EC /* CSJumpSensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSJumpSensor.m; sourceTree = "<group>"; };
-		3E820DEA15D40B180001A3EC /* CSLocationSensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSLocationSensor.h; sourceTree = "<group>"; };
-		3E820DEB15D40B180001A3EC /* CSLocationSensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSLocationSensor.m; sourceTree = "<group>"; };
+		3E820DEA15D40B180001A3EC /* CSLocationProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSLocationProvider.h; sourceTree = "<group>"; };
+		3E820DEB15D40B180001A3EC /* CSLocationProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSLocationProvider.m; sourceTree = "<group>"; };
 		3E820DEE15D40B180001A3EC /* CSMotionEnergySensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSMotionEnergySensor.h; sourceTree = "<group>"; };
 		3E820DEF15D40B180001A3EC /* CSMotionEnergySensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSMotionEnergySensor.m; sourceTree = "<group>"; };
 		3E820DF015D40B180001A3EC /* CSMotionFeaturesSensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSMotionFeaturesSensor.h; sourceTree = "<group>"; };
@@ -307,6 +309,10 @@
 		3EF47FB919093D3E00104D69 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZIP.m"; sourceTree = "<group>"; };
 		A96D6ECA1A5C49FF00554BBC /* Sense Library Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Sense Library Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A96D6ECD1A5C49FF00554BBC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A9902AB21A9F591A00FCB951 /* CSLocationSensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSLocationSensor.h; sourceTree = "<group>"; };
+		A9902AB31A9F591A00FCB951 /* CSLocationSensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSLocationSensor.m; sourceTree = "<group>"; };
+		A9902AB51A9F594500FCB951 /* CSVisitsSensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSVisitsSensor.h; sourceTree = "<group>"; };
+		A9902AB61A9F594500FCB951 /* CSVisitsSensor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSVisitsSensor.m; sourceTree = "<group>"; };
 		A99F99D31A5D18B100D6CB76 /* CSStorageTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSStorageTest.m; sourceTree = "<group>"; };
 		A99F99D71A5D8C1300D6CB76 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		A9FA46301A893EBB00D3D0E4 /* CSSpatialProviderTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSpatialProviderTest.h; sourceTree = "<group>"; };
@@ -575,8 +581,8 @@
 				3E820DE715D40B180001A3EC /* CSDynamicSensor.m */,
 				3E820DE815D40B180001A3EC /* CSJumpSensor.h */,
 				3E820DE915D40B180001A3EC /* CSJumpSensor.m */,
-				3E820DEA15D40B180001A3EC /* CSLocationSensor.h */,
-				3E820DEB15D40B180001A3EC /* CSLocationSensor.m */,
+				3E820DEA15D40B180001A3EC /* CSLocationProvider.h */,
+				3E820DEB15D40B180001A3EC /* CSLocationProvider.m */,
 				3E820DEE15D40B180001A3EC /* CSMotionEnergySensor.h */,
 				3E820DEF15D40B180001A3EC /* CSMotionEnergySensor.m */,
 				3E820DF015D40B180001A3EC /* CSMotionFeaturesSensor.h */,
@@ -589,6 +595,8 @@
 				3E820DF715D40B180001A3EC /* CSOrientationSensor.m */,
 				3E820DF815D40B180001A3EC /* CSOrientationStateSensor.h */,
 				3E820DF915D40B180001A3EC /* CSOrientationStateSensor.m */,
+				A9902AB51A9F594500FCB951 /* CSVisitsSensor.h */,
+				A9902AB61A9F594500FCB951 /* CSVisitsSensor.m */,
 				3E820DFA15D40B180001A3EC /* CSPreferencesSensor.h */,
 				3E820DFB15D40B180001A3EC /* CSPreferencesSensor.m */,
 				3E820DFC15D40B180001A3EC /* CSRotationSensor.h */,
@@ -604,6 +612,8 @@
 				3E74DBA6193C8AF100E471A9 /* CSActivityProcessorSensor.m */,
 				3E74DBA8193CC9AB00E471A9 /* CSStepCounterProcessorSensor.h */,
 				3E74DBA9193CC9AB00E471A9 /* CSStepCounterProcessorSensor.m */,
+				A9902AB21A9F591A00FCB951 /* CSLocationSensor.h */,
+				A9902AB31A9F591A00FCB951 /* CSLocationSensor.m */,
 				3E7F33A21A13AA9100957AE2 /* CSTimeZoneSensor.h */,
 				3E7F33A31A13AA9100957AE2 /* CSTimeZoneSensor.m */,
 			);
@@ -888,7 +898,7 @@
 				3E820E2715D40B190001A3EC /* CSConnectionSensor.m in Sources */,
 				3E820E2915D40B190001A3EC /* CSDynamicSensor.m in Sources */,
 				3E820E2B15D40B190001A3EC /* CSJumpSensor.m in Sources */,
-				3E820E2D15D40B190001A3EC /* CSLocationSensor.m in Sources */,
+				3E820E2D15D40B190001A3EC /* CSLocationProvider.m in Sources */,
 				3E820E3115D40B190001A3EC /* CSMotionEnergySensor.m in Sources */,
 				3E820E3315D40B190001A3EC /* CSMotionFeaturesSensor.m in Sources */,
 				3E820E3515D40B190001A3EC /* CSMovingSensor.m in Sources */,
@@ -896,6 +906,8 @@
 				3E820E3915D40B190001A3EC /* CSOrientationSensor.m in Sources */,
 				3E820E3B15D40B190001A3EC /* CSOrientationStateSensor.m in Sources */,
 				3E820E3D15D40B190001A3EC /* CSPreferencesSensor.m in Sources */,
+				A9902AB71A9F594500FCB951 /* CSVisitsSensor.m in Sources */,
+				A9902AB41A9F591A00FCB951 /* CSLocationSensor.m in Sources */,
 				3E820E3F15D40B190001A3EC /* CSRotationSensor.m in Sources */,
 				3E820E4015D40B190001A3EC /* CSSensor.m in Sources */,
 				3E820E4215D40B190001A3EC /* CSSpatialProvider.m in Sources */,

--- a/include/SensePlatform/CSSensorIds.h
+++ b/include/SensePlatform/CSSensorIds.h
@@ -43,5 +43,6 @@ extern NSString* const kCSSENSOR_TIME;
 extern NSString* const kCSSENSOR_TIMEZONE;
 extern NSString* const kCSSENSOR_JUMP;
 extern NSString* const kCSSENSOR_LOUDNESS;
+extern NSString* const kCSSENSOR_VISITS;
 
 #endif

--- a/include/SensePlatform/CSSettings.h
+++ b/include/SensePlatform/CSSettings.h
@@ -60,8 +60,6 @@ extern NSString* const kCSActivitySettingPrivacy;
 extern NSString* const kCSLocationSettingAccuracy;
 extern NSString* const kCSLocationSettingMinimumDistance;
 extern NSString* const kCSLocationSettingCortexAutoPausing;		/** Setting for automatically pausing location updates for two minutes after a new datapoint has come in, this might save battery life **/
-extern NSString* const kCSLocationSettingRecordVisits;			/** Setting for turning on/off the recording CLVisit objects into kCSSENSOR_VISITS **/
-extern NSString* const kCSLocationSettingRecordHeadingUpdates;	/** Setting for turning on/off the recording CLHeading objects into kCSSENSOR_HEADINGS **/
 
 //spatial settings
 extern NSString* const kCSSpatialSettingInterval;

--- a/include/SensePlatform/CSSettings.h
+++ b/include/SensePlatform/CSSettings.h
@@ -59,8 +59,9 @@ extern NSString* const kCSActivitySettingPrivacy;
 //location settings
 extern NSString* const kCSLocationSettingAccuracy;
 extern NSString* const kCSLocationSettingMinimumDistance;
-extern NSString* const kCSLocationSettingCortexAutoPausing; /*** Setting for automatically pausing location updates for two minutes after a new datapoint has come in, this might save battery life ***/
-
+extern NSString* const kCSLocationSettingCortexAutoPausing;		/** Setting for automatically pausing location updates for two minutes after a new datapoint has come in, this might save battery life **/
+extern NSString* const kCSLocationSettingRecordVisits;			/** Setting for turning on/off the recording CLVisit objects into kCSSENSOR_VISITS **/
+extern NSString* const kCSLocationSettingRecordHeadingUpdates;	/** Setting for turning on/off the recording CLHeading objects into kCSSENSOR_HEADINGS **/
 
 //spatial settings
 extern NSString* const kCSSpatialSettingInterval;

--- a/sense platform/CSSensorIds.m
+++ b/sense platform/CSSensorIds.m
@@ -41,3 +41,4 @@ NSString* const kCSSENSOR_TIME = @"time";
 NSString* const kCSSENSOR_TIMEZONE = @"time_zone";
 NSString* const kCSSENSOR_JUMP = @"jump";
 NSString* const kCSSENSOR_LOUDNESS = @"loudness";
+NSString* const kCSSENSOR_VISITS = @"visits";

--- a/sense platform/CSSensorStore.m
+++ b/sense platform/CSSensorStore.m
@@ -557,13 +557,8 @@ static CSSensorStore* sharedSensorStoreInstance = nil;
 }
 
 - (void) setBackgroundHackEnabled:(BOOL) enable {
-    for (CSSensor* s in sensors) {
-        if ([s.name isEqualToString:kCSSENSOR_LOCATION]) {
-            CSLocationProvider* locationSensor = (CSLocationProvider*)s;
-            [locationSensor setBackgroundRunningEnable:enable];
-            break;
-        }
-    }
+	//when only enabling the locationProvider and not the locationSensor the location updates are used for background monitoring but are not stored
+	locationProvider.isEnabled = YES;
 }
 
 - (void) setSyncRate: (int) newRate {

--- a/sense platform/CSSettings.m
+++ b/sense platform/CSSettings.m
@@ -59,6 +59,8 @@ NSString* const kCSActivitySettingPrivacy = @"privacy";
 NSString* const kCSLocationSettingAccuracy = @"accuracy";
 NSString* const kCSLocationSettingMinimumDistance = @"minimumDistance";
 NSString* const kCSLocationSettingCortexAutoPausing = @"autoPausing";
+NSString* const kCSLocationSettingRecordVisits = @"recordVisits";
+NSString* const kCSLocationSettingRecordHeadingUpdates = @"recordHeadings";
 
 //spatial settings
 NSString* const kCSSpatialSettingInterval = @"pollInterval";
@@ -171,6 +173,8 @@ static CSSettings* sharedSettingsInstance = nil;
     NSMutableDictionary* position = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                               @"100", kCSLocationSettingAccuracy,
                               kCSSettingNO, kCSLocationSettingCortexAutoPausing,
+							  kCSSettingNO, kCSLocationSettingRecordVisits,			// Set to NO by default because we don't know how it impacts battery life
+							  kCSSettingNO, kCSLocationSettingRecordHeadingUpdates, // Set to NO by default because we don't know how it impacts battery life
                               nil];
     NSMutableDictionary* spatial = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                               @"60", kCSSpatialSettingInterval,

--- a/sense platform/CSSettings.m
+++ b/sense platform/CSSettings.m
@@ -59,8 +59,6 @@ NSString* const kCSActivitySettingPrivacy = @"privacy";
 NSString* const kCSLocationSettingAccuracy = @"accuracy";
 NSString* const kCSLocationSettingMinimumDistance = @"minimumDistance";
 NSString* const kCSLocationSettingCortexAutoPausing = @"autoPausing";
-NSString* const kCSLocationSettingRecordVisits = @"recordVisits";
-NSString* const kCSLocationSettingRecordHeadingUpdates = @"recordHeadings";
 
 //spatial settings
 NSString* const kCSSpatialSettingInterval = @"pollInterval";
@@ -173,8 +171,6 @@ static CSSettings* sharedSettingsInstance = nil;
     NSMutableDictionary* position = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                               @"100", kCSLocationSettingAccuracy,
                               kCSSettingNO, kCSLocationSettingCortexAutoPausing,
-							  kCSSettingNO, kCSLocationSettingRecordVisits,			// Set to NO by default because we don't know how it impacts battery life
-							  kCSSettingNO, kCSLocationSettingRecordHeadingUpdates, // Set to NO by default because we don't know how it impacts battery life
                               nil];
     NSMutableDictionary* spatial = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                               @"60", kCSSpatialSettingInterval,

--- a/sense platform/sensors/CSLocationProvider.h
+++ b/sense platform/sensors/CSLocationProvider.h
@@ -1,0 +1,53 @@
+/* Copyright (©) 2012 Sense Observation Systems B.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Pim Nijdam (pim@sense-os.nl)
+ */
+
+#import <CoreLocation/CoreLocation.h>
+#import "CSLocationSensor.h"
+#import "CSVisitsSensor.h"
+
+/**
+ Provider that handles all the location related tracking
+ Receives location points and visits from the OS and processes them.
+ 
+ It uses two sensors: CSLocationSensor and CSVisitsSensor for storing location data and visit data respectively.
+ 
+ Note that if you don't need location information this provider is still necessary for running the app in the background. To make sure it uses the least amount of battery when running in the background you want to increase the desired accuracy and the auto pausing feature (both can be found in CSSettings.h)
+ */
+@interface CSLocationProvider : NSObject <CLLocationManagerDelegate>{
+
+}
+
+/** 
+ * Init method with a location sensor and visits sensor to store the data in
+ * @param  lSensor The location sensor
+ * @param vSensor The visits sensor
+ * @return Returns self
+ **/
+- (id) initWithLocationSensor: (CSLocationSensor *) lSensor andVisitsSensor: (CSVisitsSensor *) vSensor;
+
+
+/** This enabled/disables the required monitoring for in the background. It does not affect visits monitoring. In the current implementation, it means the desired accuracy is set and both location updates and significant location updates are started or stopped. Note that if the resulting location points should also be stored, the LocationSensor should be enabled separately.
+ **/
+@property (assign) BOOL isEnabled;
+
+
+/**
+ *	This enables/disables the required monitoring for in the background. It does not affect visits monitoring. In the current implementation, this means that location updates and significant location updates are enabled/disabaled. Note that when using this function, the desired accuracy should still be handled seperately throught the kCSLocationSettingAccuracy setting. 
+ * @warning This function is currently provided for backwards compatibility. It is replaced by isEnabled property.
+ * @param enable Setting whether to enable or disable the location monitoring for running in the background
+ */
+- (void) setBackgroundRunningEnable:(BOOL) enable;
+@end

--- a/sense platform/sensors/CSLocationProvider.h
+++ b/sense platform/sensors/CSLocationProvider.h
@@ -27,7 +27,7 @@
  Note that if you don't need location information this provider is still necessary for running the app in the background. To make sure it uses the least amount of battery when running in the background you want to increase the desired accuracy and the auto pausing feature (both can be found in CSSettings.h)
  */
 @interface CSLocationProvider : NSObject <CLLocationManagerDelegate>{
-
+	BOOL isEnabled;
 }
 
 /** 

--- a/sense platform/sensors/CSLocationProvider.m
+++ b/sense platform/sensors/CSLocationProvider.m
@@ -1,0 +1,230 @@
+/* Copyright (©) 2012 Sense Observation Systems B.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Pim Nijdam (pim@sense-os.nl)
+ */
+
+#import "CSLocationProvider.h"
+#import "CSSettings.h"
+#import "math.h"
+#import "CSDataStore.h"
+
+@implementation CSLocationProvider {
+    CLLocationManager* locationManager;
+	//int accuracyPreference;
+
+	CSLocationSensor *locationSensor;
+	CSVisitsSensor *visitsSensor;
+    
+    //the boolean to enable or disable the automated pausing of location updates
+    bool cortexAutoPausingEnabled;
+	NSTimer *pauseLocationSamplingTimer;
+	UIBackgroundTaskIdentifier bgTask;
+}
+
+
+- (id) init {
+	self = [super init];
+	if (self) {
+		locationManager = [[CLLocationManager alloc] init];
+		locationManager.delegate = self;
+        
+		//TODO: check if this is the best type to pick
+        locationManager.activityType = CLActivityTypeOther;
+		
+		//register for change in settings
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:kCSSettingTypeLocation] object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:@"adaptive"] object:nil];
+		
+		//init the sensors
+		visitsSensor = [[CSVisitsSensor alloc] init];
+		locationSensor = [[CSLocationSensor alloc] init];
+		
+		
+		//listen enable/disable notifications for visits sensor
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(visitsEnabledChanged:) name:[CSSettings enabledChangedNotificationNameForSensor:kCSSENSOR_VISITS] object:nil];
+	}
+	return self;
+}
+
+- (id) initWithLocationSensor: (CSLocationSensor *) lSensor andVisitsSensor: (CSVisitsSensor *) vSensor {
+	self = [super init];
+	if (self) {
+		locationManager = [[CLLocationManager alloc] init];
+		locationManager.delegate = self;
+		
+		//TODO: check if this is the best type to pick
+		locationManager.activityType = CLActivityTypeOther;
+		
+		//register for change in settings
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:kCSSettingTypeLocation] object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:@"adaptive"] object:nil];
+		
+		visitsSensor = vSensor;
+		locationSensor = lSensor;
+		
+		//listen enable/disable notifications for visits sensor
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(visitsEnabledChanged:) name:[CSSettings enabledChangedNotificationNameForSensor:kCSSENSOR_VISITS] object:nil];
+	}
+	return self;
+}
+
+// Newer delegate method
+- (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
+    for (CLLocation* location in locations) {
+        [self locationManager:manager updateToLocation: location fromLocation: nil];
+    }
+}
+
+/**
+ * Whenever a new visit update (departure or arrival) is detected, this function stores the visit data into a sensor
+ */
+- (void) locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
+	[visitsSensor storeVisit:visit];
+}
+
+
+
+// Delegate method from the CLLocationManagerDelegate protocol.
+- (void)locationManager:(CLLocationManager *)manager updateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation {
+	
+	bool accepted = [locationSensor storeLocation: newLocation withDesiredAccuracy:manager.desiredAccuracy];
+	
+    if(cortexAutoPausingEnabled && accepted){
+		
+        // Schedule location manager to run again in 120 seconds
+        UIApplication *app = [UIApplication sharedApplication];
+        bgTask = [app beginBackgroundTaskWithExpirationHandler:^{
+            bgTask = UIBackgroundTaskInvalid;
+        }];
+        
+        if (bgTask == UIBackgroundTaskInvalid) {
+            NSLog(@"This application does not support background mode");
+        }
+        
+        [locationManager stopUpdatingLocation];
+		
+		//TODO: make the interval a setting
+		//TODO: check if the interval is not higher than the required sample frequency for location updates;
+        pauseLocationSamplingTimer = [NSTimer scheduledTimerWithTimeInterval:180 target:self selector:@selector(turnOnLocationSampling)  userInfo:nil repeats:NO];
+        [[NSRunLoop currentRunLoop] addTimer:pauseLocationSamplingTimer forMode:NSRunLoopCommonModes];
+    }
+    
+}
+
+- (void) turnOnLocationSampling {
+    
+    NSLog(@"Restarting location updates");
+    [locationManager startUpdatingLocation];
+    
+    //NSLog(@"Background Time:%f",[[UIApplication sharedApplication] backgroundTimeRemaining]);
+    [[UIApplication sharedApplication] endBackgroundTask:bgTask];
+}
+
+- (void) locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
+    NSLog(@"Location manager failed with error %@", error);
+}
+
+- (void) locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    NSString* statusString = @"Unknown";
+    switch (status) {
+        case kCLAuthorizationStatusAuthorizedAlways:
+            statusString = @"authorized always";
+            break;
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            statusString = @"authorized when in use";
+            break;
+        case kCLAuthorizationStatusDenied:
+            statusString = @"authorization denied";
+            break;
+        case kCLAuthorizationStatusNotDetermined:
+            statusString = @"authorization undetermined";
+            break;
+        case kCLAuthorizationStatusRestricted:
+            statusString = @"authorization restricted";
+            break;
+    }
+    NSLog(@"New location authorization: %@", statusString);
+}
+
+
+- (BOOL) isEnabled {
+	return self.isEnabled;
+}
+
+- (void) setIsEnabled:(BOOL) enable {
+	
+	NSLog(@"%@ location provider", enable ? @"Enabling":@"Disabling");
+	
+	if (enable) {
+		@try {
+			locationManager.desiredAccuracy = [[[CSSettings sharedSettings] getSettingType:kCSSettingTypeLocation setting:kCSLocationSettingAccuracy] intValue];
+		} @catch (NSException* e) {
+			NSLog(@"Exception setting position accuracy: %@", e);
+		}
+		
+		//set this here instead of when the sensor is enabled as otherwise the cortex testscript won't work
+		locationManager.pausesLocationUpdatesAutomatically = NO;
+
+		if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+			[locationManager performSelectorOnMainThread:@selector(requestAlwaysAuthorization) withObject:nil waitUntilDone:YES];
+		}
+		
+		//NOTE: using only significant location updates doesn't allow the phone to sense while running in the background
+		[locationManager performSelectorOnMainThread:@selector(startUpdatingLocation) withObject:nil waitUntilDone:YES];
+		[locationManager performSelectorOnMainThread:@selector(startMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
+	}
+	else {
+		[pauseLocationSamplingTimer invalidate];
+		[locationManager performSelectorOnMainThread:@selector(stopUpdatingLocation) withObject:nil waitUntilDone:NO];
+		[locationManager performSelectorOnMainThread:@selector(stopMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
+		//[locationManager stopUpdatingLocation];
+		//as this needs to be enabled to run in the background, rather switch to the lowest accuracy
+		//locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
+	}
+}
+
+// provided for backwards compatibility
+- (void) setBackgroundRunningEnable:(BOOL) enable {
+	[self setIsEnabled:enable];
+}
+
+- (void) visitsEnabledChanged: (NSNotification*) notification {
+	if(visitsSensor.isEnabled) {[locationManager performSelectorOnMainThread:@selector(startMonitoringVisits) withObject:nil waitUntilDone:YES];}
+	else {[locationManager performSelectorOnMainThread:@selector(stopMonitoringVisits) withObject:nil waitUntilDone:YES];}
+}
+
+- (void) settingChanged: (NSNotification*) notification  {
+	@try {
+		CSSetting* setting = notification.object;
+		NSLog(@"Location setting %@ changed to %@.", setting.name, setting.value);
+
+		if ([setting.name isEqualToString:kCSLocationSettingAccuracy]) {
+			locationManager.desiredAccuracy = [setting.value integerValue];
+        } else if ([setting.name isEqualToString:kCSLocationSettingCortexAutoPausing]) {
+            cortexAutoPausingEnabled = [setting.value boolValue];
+        } else if ([setting.name isEqualToString:@"interval"]) {
+        } else if ([setting.name isEqualToString:@"locationAdaptive"]) {
+		}
+	}
+	@catch (NSException * e) {
+		NSLog(@"LocationProvider: Exception thrown while applying location settings: %@", e);
+	}
+}
+
+- (void) dealloc {
+	//self.isEnabled = NO;
+	[self setIsEnabled:NO];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+@end

--- a/sense platform/sensors/CSLocationProvider.m
+++ b/sense platform/sensors/CSLocationProvider.m
@@ -53,6 +53,7 @@
 		
 		//listen enable/disable notifications for visits sensor
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(visitsEnabledChanged:) name:[CSSettings enabledChangedNotificationNameForSensor:kCSSENSOR_VISITS] object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationsEnabledChanged:) name:[CSSettings enabledChangedNotificationNameForSensor:kCSSENSOR_VISITS] object:nil];
 	}
 	return self;
 }
@@ -163,6 +164,11 @@
 }
 
 - (void) setIsEnabled:(BOOL) enable {
+	[self enableLocationUpdates:enable];
+	self.isEnabled = enable;
+}
+
+- (void) enableLocationUpdates:(BOOL) enable {
 	
 	NSLog(@"%@ location provider", enable ? @"Enabling":@"Disabling");
 	
@@ -197,6 +203,15 @@
 // provided for backwards compatibility
 - (void) setBackgroundRunningEnable:(BOOL) enable {
 	[self setIsEnabled:enable];
+}
+
+// when the location sensor gets enabled we should start location updates; when it gets disabled, we turn it back to the location providers setting
+- (void) locationsEnabledChanged: (NSNotification*) notification {
+	if(locationSensor.isEnabled) {
+		[self enableLocationUpdates:locationSensor.isEnabled];
+	} else {
+		[self enableLocationUpdates:self.isEnabled];
+	}
 }
 
 - (void) visitsEnabledChanged: (NSNotification*) notification {

--- a/sense platform/sensors/CSLocationProvider.m
+++ b/sense platform/sensors/CSLocationProvider.m
@@ -160,12 +160,12 @@
 
 
 - (BOOL) isEnabled {
-	return self.isEnabled;
+	return isEnabled;
 }
 
 - (void) setIsEnabled:(BOOL) enable {
 	[self enableLocationUpdates:enable];
-	self.isEnabled = enable;
+	isEnabled = enable;
 }
 
 - (void) enableLocationUpdates:(BOOL) enable {

--- a/sense platform/sensors/CSLocationSensor.h
+++ b/sense platform/sensors/CSLocationSensor.h
@@ -1,34 +1,25 @@
-/* Copyright (©) 2012 Sense Observation Systems B.V.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Author: Pim Nijdam (pim@sense-os.nl)
- */
+//
+//  CSLocationSensor.h
+//  SensePlatform
+//
+//  Created by Joris Janssen on 26/02/15.
+//
+//
 
 #import "CSSensor.h"
 #import <CoreLocation/CoreLocation.h>
-#import <CoreMotion/CoreMotion.h>
 
 /**
- Sensor that handles the location tracking
- Receives location points from the OS and processes them.
- 
- Note that if you don't need location information this class is still necessary for running the app in the background. To make sure it uses the least amount of battery when running in the background you want to increase the desired accuracy and the auto pausing feature (both can be found in CSSettings.h)
+ * Sensor for storing location updates
  */
-@interface CSLocationSensor : CSSensor <CLLocationManagerDelegate>{
-
+@interface CSLocationSensor : CSSensor {
 }
 
-@property (assign) BOOL isEnabled;
-
-- (void) setBackgroundRunningEnable:(BOOL) enable;
+/**
+ * Store a new location point in the location sensor. If the sensor is not enabled the point will not be stored.
+ * @param location The location object to store
+ * @param desired accuracy, used to check if the new point should be accepted or not
+ * @return returns whether the new location point was accepted. Note that if the sensor is not enabled the point will not be stored.
+ */
+- (BOOL) storeLocation: (CLLocation *) location withDesiredAccuracy: (int) desiredAccuracy;
 @end

--- a/sense platform/sensors/CSLocationSensor.m
+++ b/sense platform/sensors/CSLocationSensor.m
@@ -129,7 +129,7 @@ static CLLocation* lastAcceptedPoint;
 									CSroundedNumber(accuracy, 8), horizontalAccuracyKey,
 									CSroundedNumber(verticalAccuracy, 8), verticalAccuracyKey,
 									CSroundedNumber(speed, 8), speedKey,
-									CSroundedNumber(heading, 8), speedKey,
+									CSroundedNumber(heading, 8), headingKey,
 									nil];
 	
 	double timestamp = [eventDate timeIntervalSince1970];

--- a/sense platform/sensors/CSLocationSensor.m
+++ b/sense platform/sensors/CSLocationSensor.m
@@ -1,439 +1,186 @@
-/* Copyright (©) 2012 Sense Observation Systems B.V.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Author: Pim Nijdam (pim@sense-os.nl)
- */
+//
+//  CSLocationSensor.m
+//  SensePlatform
+//
+//  Created by Joris Janssen on 26/02/15.
+//
+//
 
 #import "CSLocationSensor.h"
-#import "CSSettings.h"
-#import "math.h"
 #import "CSDataStore.h"
 #import "Formatting.h"
 
-@implementation CSLocationSensor {
-    CLLocationManager* locationManager;
-    NSTimer *pauseLocationSamplingTimer;
-    UIBackgroundTaskIdentifier bgTask;
-	int accuracyPreference;
-	NSMutableArray* samples;
-    CLLocation* previousLocation;
-    
-    //the boolean to enable or disable the automated pausing of location updates
-    bool cortexAutoPausingEnabled;
-}
+@implementation CSLocationSensor
 
-//constants
 static NSString* longitudeKey = @"longitude";
 static NSString* latitudeKey = @"latitude";
 static NSString* altitudeKey = @"altitude";
 static NSString* horizontalAccuracyKey = @"accuracy";
 static NSString* verticalAccuracyKey = @"vertical accuracy";
 static NSString* speedKey = @"speed";
-static NSString* eventKey = @"event";
-static NSString* headingKey = @"heading";
+
+//constants
 static const int maxSamples = 7;
 static const int minDistance = 10; //meters
 static const int minInterval = 60; //seconds
 
 static CLLocation* lastAcceptedPoint;
 
+NSMutableArray* samples;
+CLLocation* previousLocation;
+
 - (NSString*) name {return kCSSENSOR_LOCATION;}
 - (NSString*) deviceType {return [self name];}
-//+ (BOOL) isAvailable {return [CLLocationManager locationServicesEnabled];}
+
 //some users might be surprised that the position sensor isn't available. So let's say it's always available, and let ios/user handle turning services on/off.
+//+ (BOOL) isAvailable {return [CLLocationManager locationServicesEnabled];}
 + (BOOL) isAvailable {return YES;}
 
 - (NSDictionary*) sensorDescription {
 	//create description for data format. programmer: make SURE it matches the format used to send data
 	NSDictionary* format = [NSDictionary dictionaryWithObjectsAndKeys:
-								@"string", eventKey,
-								@"float", longitudeKey,
-								@"float", latitudeKey,
-								@"float", altitudeKey,
-								@"float", horizontalAccuracyKey,
-								@"float", verticalAccuracyKey,
-								@"float", speedKey,
-								@"float", headingKey,
-								nil];
+							@"float", longitudeKey,
+							@"float", latitudeKey,
+							@"float", altitudeKey,
+							@"float", horizontalAccuracyKey,
+							@"float", verticalAccuracyKey,
+							@"float", speedKey,
+							nil];
 	
 	//make string, as per spec
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:format options:0 error:&error];
+	NSError* error = nil;
+	NSData* jsonData = [NSJSONSerialization dataWithJSONObject:format options:0 error:&error];
 	NSString* json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
+	
 	return [NSDictionary dictionaryWithObjectsAndKeys:
-				[self name], @"name",
-				[self deviceType], @"device_type",
-				@"", @"pager_type",
-				@"json", @"data_type",
-				json, @"data_structure",
-				nil];
+			[self name], @"name",
+			[self deviceType], @"device_type",
+			@"", @"pager_type",
+			@"json", @"data_type",
+			json, @"data_structure",
+			nil];
 }
 
 - (id) init {
 	self = [super init];
 	if (self) {
-		locationManager = [[CLLocationManager alloc] init];
-		locationManager.delegate = self;
-        
-//TODO: check if this is the best type to pick
-        locationManager.activityType = CLActivityTypeOther;
-		//register for change in settings
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:kCSSettingTypeLocation] object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingChanged:) name:[CSSettings settingChangedNotificationNameForType:@"adaptive"] object:nil];
 		
 		samples = [[NSMutableArray alloc] initWithCapacity:maxSamples];
-        previousLocation = nil;
+		previousLocation = nil;
 	}
+	
 	return self;
 }
 
-// Newer delegate method
-- (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
-    for (CLLocation* location in locations) {
-        [self locationManager:manager updateToLocation: location fromLocation: nil];
-    }
-}
-
-/**
- * Whenever a new heading update is detected, this function stores the heading data into a sensor
- */
-- (void) locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading	{
-
-	NSString *event = @"headingUpdate";
-	NSDate *eventDate = [newHeading timestamp];
-	
-	double latitude = -1.0;
-	double longitude = -1.0;
-	double accuracy = 0.0;
-	double speed = -1.0;
-	double altitude = -1.0;
-	double verticalAccuracy = 0.0;
-	double heading = [newHeading trueHeading];
-	
-	NSMutableDictionary* newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-									event, eventKey,
-									CSroundedNumber(longitude, 8), longitudeKey,
-									CSroundedNumber(latitude, 8), latitudeKey,
-									CSroundedNumber(altitude, 8), altitudeKey,
-									CSroundedNumber(accuracy, 8), horizontalAccuracyKey,
-									CSroundedNumber(verticalAccuracy, 8), verticalAccuracyKey,
-									CSroundedNumber(speed, 8), speedKey,
-									CSroundedNumber(heading, 8), headingKey,
-									nil];
-	
-	double timestamp = [eventDate timeIntervalSince1970];
-	
-	NSDictionary* valueTimestampPair = [NSDictionary dictionaryWithObjectsAndKeys:
-										newItem, @"value",
-										CSroundedNumber(timestamp, 3), @"date",
-										nil];
-	
-	[dataStore commitFormattedData:valueTimestampPair forSensorId:self.sensorId];
-}
-
-/**
- * Whenever a new visit update (departure or arrival) is detected, this function stores the visit data into a sensor
- */
-- (void) locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
-	
-	NSString *event;
-	NSDate *eventDate;
-	
-	if ([[visit departureDate] isEqualToDate: [NSDate distantFuture]]) {
-		// User has arrived, but not left, the location
-		event = @"arrival";
-		eventDate = [visit arrivalDate];
-	} else {
-		// The visit is complete, the user has left
-		event = @"departure";
-		eventDate = [visit departureDate];
-	}
-	
-	double latitude = [visit coordinate].latitude;
-	double longitude = [visit coordinate].longitude;
-	double accuracy = [visit horizontalAccuracy];
-	double speed = 0.0;
-	double altitude = -1.0;
-	double verticalAccuracy = 0.0;
-	double heading = -1.0;
-	
-	NSMutableDictionary* newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-									event, eventKey,
-									CSroundedNumber(longitude, 8), longitudeKey,
-									CSroundedNumber(latitude, 8), latitudeKey,
-									CSroundedNumber(altitude, 8), altitudeKey,
-									CSroundedNumber(accuracy, 8), horizontalAccuracyKey,
-									CSroundedNumber(verticalAccuracy, 8), verticalAccuracyKey,
-									CSroundedNumber(speed, 8), speedKey,
-									CSroundedNumber(heading, 8), headingKey,
-									nil];
-	
-	double timestamp = [eventDate timeIntervalSince1970];
-	
-	NSDictionary* valueTimestampPair = [NSDictionary dictionaryWithObjectsAndKeys:
-										newItem, @"value",
-										CSroundedNumber(timestamp, 3), @"date",
-										nil];
-	
-	[dataStore commitFormattedData:valueTimestampPair forSensorId:self.sensorId];
-}
-
-// Delegate method from the CLLocationManagerDelegate protocol.
-- (void)locationManager:(CLLocationManager *)manager
-    updateToLocation:(CLLocation *)newLocation
-		   fromLocation:(CLLocation *)oldLocation {
-
-    if (isEnabled == NO) {
-        return;
-    }
-	
-	NSString* event = @"location_update";
-	double longitude = newLocation.coordinate.longitude;
-	double latitude = newLocation.coordinate.latitude;
-	double altitude = newLocation.altitude;
-	double horizontalAccuracy = newLocation.horizontalAccuracy;
-	double verticalAccuracy = newLocation.verticalAccuracy;
-	double speed = newLocation.speed;
-    
+- (BOOL) rejectNewLocationPoint: (CLLocation *) newLocation withDesiredAccuracy: (int) desiredAccuracy{
 	
 	/* filter on location accuracy */
-    bool rejected = false;
+	bool rejected = false;
+	
 	//remove least recent sample
 	if ([samples count] >= maxSamples)
 		[samples removeLastObject];
+	
 	//insert this sample at beginning
-	[samples insertObject:[NSNumber numberWithDouble: horizontalAccuracy ] atIndex:0];
+	[samples insertObject:[NSNumber numberWithDouble: newLocation.horizontalAccuracy] atIndex:0];
 	
 	//sort so we can calculate quantiles
 	NSSortDescriptor *sorter = [[NSSortDescriptor alloc] initWithKey:@"self" ascending:YES];
 	NSArray *sorters = [[NSArray alloc] initWithObjects:sorter, nil];
 	NSArray *sortedSamples = [samples sortedArrayUsingDescriptors:sorters];
-
+	
 	
 	//100m, or within desiredAccuracy is a good start
-	int goodStartAccuracy = locationManager.desiredAccuracy;
+	int goodStartAccuracy = desiredAccuracy;
 	if (goodStartAccuracy < 100) goodStartAccuracy = 100;
-    int adaptedGoodEnoughAccuracy;
+	int adaptedGoodEnoughAccuracy;
+	
 	//decide wether to accept the sample
 	if ([samples count] >= maxSamples) {
 		//we expect within 2* second quartile, this rejects outliers
 		adaptedGoodEnoughAccuracy = [[sortedSamples objectAtIndex:(int)(maxSamples/2)] intValue] * 2;
 		//NSLog(@"adapted: %d", adaptedGoodEnoughAccuracy);
-		if (horizontalAccuracy <= adaptedGoodEnoughAccuracy)
+		if (newLocation.horizontalAccuracy <= adaptedGoodEnoughAccuracy)
 			;
 		else
-			rejected = YES;;
+			rejected = YES;
 	}
-	else if ([samples count] < maxSamples && horizontalAccuracy <= goodStartAccuracy)
+	else if ([samples count] < maxSamples && newLocation.horizontalAccuracy <= goodStartAccuracy)
 		; //accept if we haven't collected many samples, but accuracy is alread quite good
-	else 
+	else
 		rejected = YES; //reject sample
-    if (rejected)
-        return;
-    
-    /* filter points when not moving. This avoids a lot of unnecessary points to upload. Without this filter at best accuracy it will generate a point every second. */
-    if (lastAcceptedPoint != nil) {
-        double distance = [newLocation distanceFromLocation:lastAcceptedPoint];
-        double interval = [newLocation.timestamp timeIntervalSinceDate:lastAcceptedPoint.timestamp];
-        if (!(distance >= minDistance || interval >= minInterval || newLocation.horizontalAccuracy < lastAcceptedPoint.horizontalAccuracy))
-            return;
-    }
-    lastAcceptedPoint = newLocation;
+	
+	/* filter points when not moving. This avoids a lot of unnecessary points to upload. Without this filter at best accuracy it will generate a point every second. */
+	if (lastAcceptedPoint != nil) {
+		double distance = [newLocation distanceFromLocation:lastAcceptedPoint];
+		double interval = [newLocation.timestamp timeIntervalSinceDate:lastAcceptedPoint.timestamp];
+		if (!(distance >= minDistance || interval >= minInterval || newLocation.horizontalAccuracy < lastAcceptedPoint.horizontalAccuracy))
+			rejected = YES;
+	}
+	
+	if(! rejected) {
+		lastAcceptedPoint = newLocation;
+	}
+	
+	return rejected;
+}
 
+- (BOOL) storeLocation: (CLLocation *) location withDesiredAccuracy: (int) desiredAccuracy{
 
+	if ([self rejectNewLocationPoint: location withDesiredAccuracy:desiredAccuracy]) {
+		return false;
+	}
+	
+	if (isEnabled == NO) {
+		return true;
+	}
+	
+	double longitude = location.coordinate.longitude;
+	double latitude = location.coordinate.latitude;
+	double altitude = location.altitude;
+	double horizontalAccuracy = location.horizontalAccuracy;
+	double verticalAccuracy = location.verticalAccuracy;
+	double speed = location.speed;
+	
 	NSMutableDictionary* newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-									event, eventKey,
 									CSroundedNumber(longitude, 8), longitudeKey,
 									CSroundedNumber(latitude, 8), latitudeKey,
 									CSroundedNumber(horizontalAccuracy, 8), horizontalAccuracyKey,
 									nil];
-	if (newLocation.speed >=0) {
+	if (location.speed >=0) {
 		[newItem setObject:CSroundedNumber(speed, 1) forKey:speedKey];
 	}
-	if (newLocation.verticalAccuracy >= 0) {
+	if (location.verticalAccuracy >= 0) {
 		[newItem setObject:CSroundedNumber(altitude, 0) forKey:altitudeKey];
 		[newItem setObject:CSroundedNumber(verticalAccuracy, 0) forKey:verticalAccuracyKey];
 	}
 	
-	[newItem setObject:CSroundedNumber(-1.0, 0) forKey:headingKey];
-	
-	double timestamp = [newLocation.timestamp timeIntervalSince1970];
+	double timestamp = [location.timestamp timeIntervalSince1970];
 	
 	NSDictionary* valueTimestampPair = [NSDictionary dictionaryWithObjectsAndKeys:
 										newItem, @"value",
-										CSroundedNumber(timestamp, 3), @"date",
+									 	CSroundedNumber(timestamp, 3), @"date",
 										nil];
+	
+	
 	[dataStore commitFormattedData:valueTimestampPair forSensorId:self.sensorId];
-    
-    if(cortexAutoPausingEnabled) {
-        
-        NSLog(@"Pausing location sampling ...");
-        
-        // Schedule location manager to run again in 120 seconds
-        UIApplication *app = [UIApplication sharedApplication];
-        bgTask = [app beginBackgroundTaskWithExpirationHandler:^{
-            bgTask = UIBackgroundTaskInvalid;
-            NSLog(@"End of tolerate time. Application should be suspended now if we do not ask more 'tolerance'");
-        }];
-        
-        if (bgTask == UIBackgroundTaskInvalid) {
-            NSLog(@"This application does not support background mode");
-        } else {
-            //if application supports background mode, we'll see this log.
-            //NSLog(@"Application will continue to run in background");
-        }
-        
-        [locationManager stopUpdatingLocation];
-        pauseLocationSamplingTimer = [NSTimer scheduledTimerWithTimeInterval:180 target:self selector:@selector(turnOnLocationSampling)  userInfo:nil repeats:NO];
-        [[NSRunLoop currentRunLoop] addTimer:pauseLocationSamplingTimer forMode:NSRunLoopCommonModes];
-    }
-    
+	
+	return true;
 }
 
-- (void) turnOnLocationSampling {
-    
-    NSLog(@"Restarting location updates");
-    [locationManager startUpdatingLocation];
-    
-    //NSLog(@"Background Time:%f",[[UIApplication sharedApplication] backgroundTimeRemaining]);
-    [[UIApplication sharedApplication] endBackgroundTask:bgTask];
-}
-
-- (void) locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
-    NSLog(@"Location manager failed with error %@", error);
-}
-
-- (void) locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    NSString* statusString = @"Unknown";
-    switch (status) {
-        case kCLAuthorizationStatusAuthorizedAlways:
-            statusString = @"authorized always";
-            break;
-        case kCLAuthorizationStatusAuthorizedWhenInUse:
-            statusString = @"authorized when in use";
-            break;
-        case kCLAuthorizationStatusDenied:
-            statusString = @"authorization denied";
-            break;
-        case kCLAuthorizationStatusNotDetermined:
-            statusString = @"authorization undetermined";
-            break;
-        case kCLAuthorizationStatusRestricted:
-            statusString = @"authorization restricted";
-            break;
-    }
-    NSLog(@"New location authorization: %@", statusString);
-}
 - (BOOL) isEnabled {return isEnabled;}
 
 - (void) setIsEnabled:(BOOL) enable {
-	//only react to changes
-	//if (enable == isEnabled) return;
-	
-	NSLog(@"%@ location sensor", enable ? @"Enabling":@"Disabling");
-	if (enable) {
-		@try {
-			locationManager.desiredAccuracy = [[[CSSettings sharedSettings] getSettingType:kCSSettingTypeLocation setting:kCSLocationSettingAccuracy] intValue];
-		} @catch (NSException* e) {
-			NSLog(@"Exception setting position accuracy: %@", e);
-		}
-		
-        //set this here instead of when the sensor is enabled as otherwise the cortex testscript won't work
-        locationManager.pausesLocationUpdatesAutomatically = NO;
-		
-		[samples removeAllObjects];
-		
-        if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
-            [locationManager performSelectorOnMainThread:@selector(requestAlwaysAuthorization) withObject:nil waitUntilDone:YES];
-        }
-		
-        //NOTE: using only significant location updates doesn't allow the phone to sense while running in the background
-        [locationManager performSelectorOnMainThread:@selector(startUpdatingLocation) withObject:nil waitUntilDone:YES];
-        [locationManager performSelectorOnMainThread:@selector(startMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
-		
-		if([[[CSSettings sharedSettings] getSettingType:kCSSettingTypeLocation setting:kCSLocationSettingRecordVisits] boolValue]) {
-			[locationManager startMonitoringVisits];
-		}
-		else {
-			[locationManager stopMonitoringVisits];
-		}
-		
-		if([[[CSSettings sharedSettings] getSettingType:kCSSettingTypeLocation setting:kCSLocationSettingRecordHeadingUpdates] boolValue]) {
-			[locationManager startUpdatingHeading];
-		}
-		else {
-			[locationManager stopUpdatingHeading];
-		}
-		
-	}
-	else {
-        [pauseLocationSamplingTimer invalidate];
-        [locationManager performSelectorOnMainThread:@selector(stopUpdatingLocation) withObject:nil waitUntilDone:NO];
-        [locationManager performSelectorOnMainThread:@selector(stopMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
-		[locationManager stopUpdatingHeading];
-		[locationManager stopMonitoringVisits];
-		//[locationManager stopUpdatingLocation];
-        //as this needs to be enabled to run in the background, rather switch to the lowest accuracy
-        //locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
-		[samples removeAllObjects];
-	}
+	NSLog(@"%@ %@ sensor (id=%@).", enable ? @"Enabling":@"Disabling", [self class], self.sensorId);
 	isEnabled = enable;
+	[samples removeAllObjects];
 }
 
-- (void) setBackgroundRunningEnable:(BOOL) enable {
-    if (enable) {
-        if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
-            [locationManager performSelectorOnMainThread:@selector(requestAlwaysAuthorization) withObject:nil waitUntilDone:YES];
-        }
-        [locationManager performSelectorOnMainThread:@selector(startUpdatingLocation) withObject:nil waitUntilDone:YES];
-        [locationManager performSelectorOnMainThread:@selector(startMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
-    } else {
-        [locationManager performSelectorOnMainThread:@selector(stopUpdatingLocation) withObject:nil waitUntilDone:YES];
-        [locationManager performSelectorOnMainThread:@selector(stopMonitoringSignificantLocationChanges) withObject:nil waitUntilDone:YES];
-    }
-}
-
-- (void) settingChanged: (NSNotification*) notification  {
-	@try {
-		CSSetting* setting = notification.object;
-		NSLog(@"Location setting %@ changed to %@.", setting.name, setting.value);
-
-		if ([setting.name isEqualToString:kCSLocationSettingAccuracy]) {
-			locationManager.desiredAccuracy = [setting.value integerValue];
-        } else if ([setting.name isEqualToString:kCSLocationSettingCortexAutoPausing]) {
-            cortexAutoPausingEnabled = [setting.value boolValue];
-        } else if ([setting.name isEqualToString:@"interval"]) {
-        } else if ([setting.name isEqualToString:@"locationAdaptive"]) {
-		} else if ([setting.name isEqualToString:kCSLocationSettingRecordVisits]) {
-			//Setting for starting and stopping the monitoring of visits
-			if([setting.value boolValue]) {[locationManager startMonitoringVisits];}
-			else {[locationManager stopMonitoringVisits];}
-		} else if ([setting.name isEqualToString:kCSLocationSettingRecordHeadingUpdates]) {
-			//Setting for starting and stopping the monitoring of heading updates
-			if([setting.value boolValue]) {[locationManager startUpdatingHeading];}
-			else {[locationManager stopUpdatingHeading];}
-		}
-
-	}
-	@catch (NSException * e) {
-		NSLog(@"LocationSensor: Exception thrown while applying location settings: %@", e);
-	}
-}
 
 - (void) dealloc {
 	self.isEnabled = NO;
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	
 }
+
+
 @end

--- a/sense platform/sensors/CSVisitsSensor.h
+++ b/sense platform/sensors/CSVisitsSensor.h
@@ -1,0 +1,24 @@
+//
+//  CSVisitsSensor.h
+//  SensePlatform
+//
+//  Created by Joris Janssen on 26/02/15.
+//
+//
+
+#import "CSSensor.h"
+#import <CoreLocation/CoreLocation.h>
+
+/**
+ * Sensor for storing visits
+ */
+@interface CSVisitsSensor : CSSensor {
+}
+
+/**
+ * Processes a new visit object and stores it in the sensor. If the sensor is not enabled the point will not be stored.
+ * @param visit The visit object
+ */
+- (void) storeVisit: (CLVisit *) visit;
+
+@end

--- a/sense platform/sensors/CSVisitsSensor.m
+++ b/sense platform/sensors/CSVisitsSensor.m
@@ -1,0 +1,113 @@
+//
+//  CSVisitsSensor.m
+//  SensePlatform
+//
+//  Created by Joris Janssen on 26/02/15.
+//
+//
+
+#import "CSVisitsSensor.h"
+#import "CSDataStore.h"
+#import "Formatting.h"
+
+
+@implementation CSVisitsSensor
+
+static NSString* longitudeKey = @"longitude";
+static NSString* latitudeKey = @"latitude";
+static NSString* accuracyKey = @"accuracy";
+static NSString* eventKey = @"event";
+
+	
+- (NSString*) name {return kCSSENSOR_VISITS;}
+- (NSString*) deviceType {return [self name];}
+//TODO: check for availability
++ (BOOL) isAvailable {
+	return YES;
+}
+
+- (NSDictionary*) sensorDescription {
+	//create description for data format. programmer: make SURE it matches the format used to send data
+	NSDictionary* format = [NSDictionary dictionaryWithObjectsAndKeys:
+							@"string", eventKey,
+							@"float", longitudeKey,
+							@"float", latitudeKey,
+							@"float", accuracyKey,
+							nil];
+	//make string, as per spec
+	NSError* error = nil;
+	NSData* jsonData = [NSJSONSerialization dataWithJSONObject:format options:0 error:&error];
+	NSString* json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+	
+	return [NSDictionary dictionaryWithObjectsAndKeys:
+			[self name], @"name",
+			[self deviceType], @"device_type",
+			@"", @"pager_type",
+			@"json", @"data_type",
+			json, @"data_structure",
+			nil];
+}
+
+- (id) init {
+	self = [super init];
+	
+	if (self) {
+	}
+	
+	return self;
+}
+
+- (void) storeVisit: (CLVisit *) visit {
+	if (isEnabled == NO) {
+		return;
+	}
+	
+	NSString *event;
+	NSDate *eventDate;
+	
+	if ([[visit departureDate] isEqualToDate: [NSDate distantFuture]]) {
+		// User has arrived, but not left, the location
+		event = @"arrival";
+		eventDate = [visit arrivalDate];
+	} else {
+		// The visit is complete, the user has left
+		event = @"departure";
+		eventDate = [visit departureDate];
+	}
+	
+	double latitude = [visit coordinate].latitude;
+	double longitude = [visit coordinate].longitude;
+	double accuracy = [visit horizontalAccuracy];
+
+	
+	NSMutableDictionary* newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+									event, eventKey,
+									CSroundedNumber(longitude, 8), longitudeKey,
+									CSroundedNumber(latitude, 8), latitudeKey,
+									CSroundedNumber(accuracy, 8), accuracyKey,
+									nil];
+	
+	double timestamp = [eventDate timeIntervalSince1970];
+	
+	NSDictionary* valueTimestampPair = [NSDictionary dictionaryWithObjectsAndKeys:
+										newItem, @"value",
+										CSroundedNumber(timestamp, 3), @"date",
+										nil];
+	
+	[dataStore commitFormattedData:valueTimestampPair forSensorId:self.sensorId];
+}
+
+- (BOOL) isEnabled {return isEnabled;}
+
+- (void) setIsEnabled:(BOOL) enable {
+	NSLog(@"%@ %@ sensor (id=%@).", enable ? @"Enabling":@"Disabling", [self class], self.sensorId);
+	isEnabled = enable;
+}
+
+
+- (void) dealloc {
+	self.isEnabled = NO;
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+@end


### PR DESCRIPTION
@yulrizka I have adjusted the setup for location monitoring. There is now a CSLocationProvider that handles all the location related notifications and updates. It has two sensors, a location sensor for the location points and a visits sensor for the visits points. Each sensor can be individually enabled. Moreover, the location provider can be enabled/disabled as well, this can be used to do background sensing without actually storing the data. Data seems to be coming in correctly for me, although I haven't moved so no visits yet. Everything should be backwards compatible as well.

Could you QA and merge?