### PR TITLE
Disabled CSActivityProcessorSensor so that senseplatform doesnt ask a…

### DIFF
--- a/sense platform/CSSensorStore.m
+++ b/sense platform/CSSensorStore.m
@@ -149,7 +149,7 @@ static CSSensorStore* sharedSensorStoreInstance = nil;
                             //[CSJumpSensor class],
 							//[PreferencesSensor class],
 							//[BloodPressureSensor class],
-                            [CSActivityProcessorSensor class],
+							//[CSActivityProcessorSensor class],
                             [CSTimeZoneSensor class],
                             //[CSStepCounterProcessorSensor class],
 							nil];


### PR DESCRIPTION
…nnoying permission for something it doesnt actually use

@Tubyhes hey could you QA and merge? I have verified with dogeprobe that this was actually a problem, and is now fixed. We don't need the motion sensor for our current operations (this is the special chip from Apple). So not instantiating the sensor that provides this solves a lot of headaches because Apple rejected the app because of this