### PR TITLE
Added a fix for iOS9.0. Setting allowsBackgroundLocationUpdates to YE…

### DIFF
--- a/sense platform/sensors/CSLocationProvider.m
+++ b/sense platform/sensors/CSLocationProvider.m
@@ -241,13 +241,17 @@
 }
 
 - (void) requestPermission {
-    // check to make sure we dont do this on iOS < 8
+    // for iOS versions where LocationManagre has requestAlwaysAuthorization(iOS8 or higher)
     if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
         // check if we haven't already asked permissions
         if (!([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedAlways)) {
             // request the permissions
             [locationManager performSelectorOnMainThread:@selector(requestAlwaysAuthorization) withObject:nil waitUntilDone:YES];
         }
+    }
+    // for iOS versions where LocationManagre has the property allowsBackgroundLocationUpdates(iOS9 or higher)
+    if ([locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]){
+        locationManager.allowsBackgroundLocationUpdates = YES;
     }
 }
 

--- a/sense platform/sensors/CSLocationProvider.m
+++ b/sense platform/sensors/CSLocationProvider.m
@@ -250,8 +250,12 @@
         }
     }
     // for iOS versions where LocationManagre has the property allowsBackgroundLocationUpdates(iOS9 or higher)
-    if ([locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]){
-        locationManager.allowsBackgroundLocationUpdates = YES;
+    NSArray* backgroundModes  = [[NSBundle mainBundle].infoDictionary objectForKey:@"UIBackgroundModes"];
+    
+    if(backgroundModes && [backgroundModes containsObject:@"location"]) {
+        if ([locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]){
+            [locationManager setAllowsBackgroundLocationUpdates:YES];
+        }
     }
 }
 


### PR DESCRIPTION
…S in order to allow services to run in the background
### Fixed
- time active or any background service not measuring while the app is in the background on iOS9.0 or higher
